### PR TITLE
Configure GitHub Pages deployment for frontend

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,57 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build static site
+        working-directory: frontend
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL || secrets.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_WS_URL: ${{ vars.NEXT_PUBLIC_WS_URL || secrets.NEXT_PUBLIC_WS_URL }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .next/
+out/
 .env*
 .DS_Store
 coverage/

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import './globals.css';
+import '../styles/globals.css';
 
 export const metadata: Metadata = {
   title: 'TransitScope – Greater Manchester realtime map',

--- a/frontend/components/RouteSidebar.tsx
+++ b/frontend/components/RouteSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { getRoutes, type Route } from '../lib/api';
+import { API_BASE_URL } from '../lib/config';
 
 function modeLabel(mode: Route['mode']) {
   return mode === 'bus' ? 'Bus' : 'Tram';
@@ -87,7 +88,7 @@ export default function RouteSidebar() {
           everything offline.
         </p>
         <p>
-          Backend URL: <code className="bg-stone-100 px-1 py-0.5 rounded">{process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000'}</code>
+          Backend URL: <code className="bg-stone-100 px-1 py-0.5 rounded">{API_BASE_URL}</code>
         </p>
       </div>
     </aside>

--- a/frontend/components/TransportMap.tsx
+++ b/frontend/components/TransportMap.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import maplibregl, { Map as MapLibreMap, Marker } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { getSnapshot, type VehiclePosition } from '../lib/api';
+import { API_BASE_URL, EXPLICIT_WS_URL } from '../lib/config';
 
 const TILE_STYLE = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
@@ -13,12 +14,10 @@ interface MarkerState {
 }
 
 function resolveWebSocketUrl() {
-  const explicit = process.env.NEXT_PUBLIC_WS_URL;
-  if (explicit) {
-    return explicit;
+  if (EXPLICIT_WS_URL) {
+    return EXPLICIT_WS_URL;
   }
-  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000';
-  return apiBase.replace(/^http/, 'ws').replace(/\/?$/, '') + '/live';
+  return API_BASE_URL.replace(/^http/, 'ws').replace(/\/?$/, '') + '/live';
 }
 
 function createMarker(vehicle: VehiclePosition) {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000';
+import { API_BASE_URL } from './config';
 
 export interface Route {
   id: string;

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,16 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:4000';
+
+function readEnv(name: string) {
+  const value = process.env[name];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const API_BASE_URL = readEnv('NEXT_PUBLIC_API_BASE_URL') ?? DEFAULT_API_BASE_URL;
+export const EXPLICIT_WS_URL = readEnv('NEXT_PUBLIC_WS_URL');
+
+export { readEnv };

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,8 +1,52 @@
+function normalizeBasePath(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim().replace(/^\/+|\/+$/g, '');
+  if (!trimmed) {
+    return '';
+  }
+
+  return `/${trimmed}`;
+}
+
+function resolveBasePath() {
+  if (typeof process.env.NEXT_PUBLIC_BASE_PATH !== 'undefined') {
+    return normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+  }
+
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    return undefined;
+  }
+
+  const [, repo] = repository.split('/');
+  if (!repo || repo.endsWith('.github.io')) {
+    return undefined;
+  }
+
+  return normalizeBasePath(repo);
+}
+
+const computedBasePath = resolveBasePath();
+const basePath = computedBasePath && computedBasePath.length > 0 ? computedBasePath : undefined;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
     typedRoutes: true
+  },
+  output: 'export',
+  trailingSlash: true,
+  images: {
+    unoptimized: true
   }
 };
+
+if (basePath) {
+  nextConfig.basePath = basePath;
+  nextConfig.assetPrefix = `${basePath}/`;
+}
 
 export default nextConfig;

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,28 @@ docker-compose up
 
 ---
 
+## 🌐 Deploying the frontend to GitHub Pages
+
+This repository now ships with a GitHub Actions workflow (`.github/workflows/deploy-frontend.yml`) that builds the Next.js
+frontend as a static export and publishes it to GitHub Pages. The build automatically adjusts the asset base path so the app
+works from `https://<username>.github.io/<repo>/`.
+
+### One-time setup
+
+1. In your repository settings, enable GitHub Pages with the "GitHub Actions" source.
+2. Define a repository variable or secret called `NEXT_PUBLIC_API_BASE_URL` that points at a publicly reachable backend URL
+   (for example, a Render/railway deployment of the API). Optionally add `NEXT_PUBLIC_WS_URL` if your WebSocket endpoint
+   lives on a different host.
+3. (Optional) Set `NEXT_PUBLIC_BASE_PATH` if you need to serve the site from a custom sub-path. Otherwise the workflow will
+   infer `/<repo>` automatically for project pages.
+
+### Deployment
+
+- Push to `main` (or trigger the workflow manually) and the site will be rebuilt and published automatically.
+- The exported site lives in `frontend/out` if you need to download the artifact or host it elsewhere.
+
+---
+
 ## 📂 Project Structure
 ```
 /frontend/         # Next.js app (MapLibre GL)


### PR DESCRIPTION
## Summary
- configure the Next.js app for static export with automatic base path detection for GitHub Pages
- centralize frontend environment configuration and sanitize API/WebSocket URLs
- add a GitHub Actions workflow and documentation for deploying the static build to GitHub Pages

## Testing
- npm --prefix frontend run lint
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3e6e896c832abb98aa082470d81c