### PR TITLE
Add interactive map overlays and route filtering

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,11 @@
+"use client";
+
 import dynamic from 'next/dynamic';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import RouteSidebar from '../components/RouteSidebar';
+import { getRoutes, type Route } from '../lib/api';
+
+type ModeFilter = 'all' | Route['mode'];
 
 const TransportMap = dynamic(() => import('../components/TransportMap'), {
   ssr: false,
@@ -11,15 +16,106 @@ const TransportMap = dynamic(() => import('../components/TransportMap'), {
   ),
 });
 
+function useRoutes() {
+  const [routes, setRoutes] = useState<Route[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      try {
+        const data = await getRoutes();
+        if (!cancelled) {
+          setRoutes(data);
+          setError(null);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setError('Could not load routes');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return useMemo(
+    () => ({
+      routes,
+      loading,
+      error,
+    }),
+    [routes, loading, error],
+  );
+}
+
+function useModeAwareRouteSelection(routes: Route[]) {
+  const [selectedMode, setSelectedMode] = useState<ModeFilter>('all');
+  const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
+
+  const handleModeChange = (mode: ModeFilter) => {
+    setSelectedMode(mode);
+    setSelectedRouteId((current) => {
+      if (!current) return current;
+      const route = routes.find((item) => item.id === current);
+      if (!route) return null;
+      if (mode === 'all' || route.mode === mode) {
+        return current;
+      }
+      return null;
+    });
+  };
+
+  const handleRouteSelect = (routeId: string | null) => {
+    setSelectedRouteId(routeId);
+    if (routeId) {
+      const route = routes.find((item) => item.id === routeId);
+      if (route && selectedMode !== 'all' && route.mode !== selectedMode) {
+        setSelectedMode(route.mode);
+      }
+    }
+  };
+
+  return {
+    selectedMode,
+    selectedRouteId,
+    setSelectedMode: handleModeChange,
+    setSelectedRouteId: handleRouteSelect,
+  };
+}
+
 export default function HomePage() {
+  const { routes, loading, error } = useRoutes();
+  const { selectedMode, selectedRouteId, setSelectedMode, setSelectedRouteId } = useModeAwareRouteSelection(routes);
+
   return (
     <main className="flex flex-1 flex-col md:flex-row">
       <div className="w-full md:w-80 bg-white border-b md:border-b-0 md:border-r border-stone-200">
-        <RouteSidebar />
+        <RouteSidebar
+          routes={routes}
+          loading={loading}
+          error={error}
+          selectedMode={selectedMode}
+          onModeChange={setSelectedMode}
+          selectedRouteId={selectedRouteId}
+          onRouteSelect={setSelectedRouteId}
+        />
       </div>
       <div className="flex-1 relative min-h-[50vh]">
         <Suspense fallback={<div className="p-4">Loading map…</div>}>
-          <TransportMap />
+          <TransportMap routes={routes} selectedMode={selectedMode} selectedRouteId={selectedRouteId} />
         </Suspense>
       </div>
     </main>

--- a/frontend/components/RouteSidebar.tsx
+++ b/frontend/components/RouteSidebar.tsx
@@ -1,34 +1,49 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { getRoutes, type Route } from '../lib/api';
+import { useMemo } from 'react';
+import type { Route } from '../lib/api';
 import { API_BASE_URL } from '../lib/config';
 
 function modeLabel(mode: Route['mode']) {
   return mode === 'bus' ? 'Bus' : 'Tram';
 }
 
-export default function RouteSidebar() {
-  const [routes, setRoutes] = useState<Route[]>([]);
-  const [selectedMode, setSelectedMode] = useState<'all' | Route['mode']>('all');
-  const [error, setError] = useState<string | null>(null);
+type ModeFilter = 'all' | Route['mode'];
 
-  useEffect(() => {
-    getRoutes()
-      .then((data) => {
-        setRoutes(data);
-        setError(null);
-      })
-      .catch((err) => {
-        console.error(err);
-        setError('Could not load routes');
-      });
-  }, []);
+interface RouteSidebarProps {
+  routes: Route[];
+  loading: boolean;
+  error: string | null;
+  selectedMode: ModeFilter;
+  onModeChange: (mode: ModeFilter) => void;
+  selectedRouteId: string | null;
+  onRouteSelect: (routeId: string | null) => void;
+}
 
+export default function RouteSidebar({
+  routes,
+  loading,
+  error,
+  selectedMode,
+  onModeChange,
+  selectedRouteId,
+  onRouteSelect,
+}: RouteSidebarProps) {
   const filteredRoutes = useMemo(() => {
     if (selectedMode === 'all') return routes;
     return routes.filter((route) => route.mode === selectedMode);
   }, [routes, selectedMode]);
+
+  const routeCountLabel = (() => {
+    if (loading) return 'Loading routes…';
+    if (error) return 'Unable to load routes';
+    if (filteredRoutes.length === 0) return 'No routes available';
+    return `${filteredRoutes.length} route${filteredRoutes.length === 1 ? '' : 's'}`;
+  })();
+
+  const handleRouteClick = (routeId: string) => {
+    onRouteSelect(selectedRouteId === routeId ? null : routeId);
+  };
 
   return (
     <aside className="h-full flex flex-col">
@@ -38,45 +53,81 @@ export default function RouteSidebar() {
       </div>
       <div className="flex gap-2 p-4 border-b border-stone-200 text-sm">
         <button
-          className={`rounded-full px-3 py-1 border ${selectedMode === 'all' ? 'border-stone-900 bg-stone-900 text-white' : 'border-stone-200 text-stone-600'}`}
-          onClick={() => setSelectedMode('all')}
+          type="button"
+          className={`rounded-full px-3 py-1 border transition-colors ${
+            selectedMode === 'all'
+              ? 'border-stone-900 bg-stone-900 text-white'
+              : 'border-stone-200 text-stone-600 hover:border-stone-300 hover:text-stone-800'
+          }`}
+          onClick={() => onModeChange('all')}
         >
           All modes
         </button>
         <button
-          className={`rounded-full px-3 py-1 border ${selectedMode === 'bus' ? 'border-bus bg-bus text-white' : 'border-stone-200 text-stone-600'}`}
-          onClick={() => setSelectedMode('bus')}
+          type="button"
+          className={`rounded-full px-3 py-1 border transition-colors ${
+            selectedMode === 'bus'
+              ? 'border-bus bg-bus text-white'
+              : 'border-stone-200 text-stone-600 hover:border-stone-300 hover:text-stone-800'
+          }`}
+          onClick={() => onModeChange('bus')}
         >
           Buses
         </button>
         <button
-          className={`rounded-full px-3 py-1 border ${selectedMode === 'tram' ? 'border-tram bg-tram text-stone-900' : 'border-stone-200 text-stone-600'}`}
-          onClick={() => setSelectedMode('tram')}
+          type="button"
+          className={`rounded-full px-3 py-1 border transition-colors ${
+            selectedMode === 'tram'
+              ? 'border-tram bg-tram text-stone-900'
+              : 'border-stone-200 text-stone-600 hover:border-stone-300 hover:text-stone-800'
+          }`}
+          onClick={() => onModeChange('tram')}
         >
           Trams
         </button>
       </div>
+      <div className="flex items-center justify-between px-4 py-2 border-b border-stone-200 text-xs uppercase tracking-wide text-stone-500">
+        <span>{routeCountLabel}</span>
+        {selectedRouteId ? <span className="text-bus">Route focused</span> : null}
+      </div>
       <div className="flex-1 overflow-y-auto">
-        {error ? (
+        {error && !loading ? (
           <p className="p-4 text-sm text-red-600">{error}</p>
         ) : (
           <ul className="divide-y divide-stone-200">
-            {filteredRoutes.map((route) => (
-              <li key={route.id} className="p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="font-medium">{route.name}</p>
-                    <p className="text-xs uppercase tracking-wide text-stone-500">{modeLabel(route.mode)}</p>
-                  </div>
-                  <span
-                    className="inline-block w-3 h-3 rounded-full"
-                    style={{ backgroundColor: route.color }}
-                    aria-hidden
-                  />
-                </div>
-              </li>
-            ))}
-            {filteredRoutes.length === 0 && !error ? (
+            {filteredRoutes.map((route) => {
+              const isSelected = selectedRouteId === route.id;
+              return (
+                <li key={route.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleRouteClick(route.id)}
+                    className={`w-full text-left p-4 flex items-center justify-between gap-3 transition-colors ${
+                      isSelected ? 'bg-stone-100/80' : 'hover:bg-stone-50'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <div>
+                      <p className="font-medium text-sm">{route.name}</p>
+                      <p className="text-xs uppercase tracking-wide text-stone-500">{modeLabel(route.mode)}</p>
+                    </div>
+                    <span
+                      className={`inline-flex items-center gap-2 rounded-full border px-2 py-1 text-xs ${
+                        isSelected ? 'border-stone-400 bg-white text-stone-700 shadow-sm' : 'border-stone-200 text-stone-600'
+                      }`}
+                    >
+                      <span
+                        className="inline-block w-2.5 h-2.5 rounded-full"
+                        style={{ backgroundColor: route.color }}
+                        aria-hidden
+                      />
+                      <span>{route.id}</span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+            {!loading && filteredRoutes.length === 0 ? (
               <li className="p-4 text-sm text-stone-500">No routes for this mode yet.</li>
             ) : null}
           </ul>
@@ -90,6 +141,13 @@ export default function RouteSidebar() {
         <p>
           Backend URL: <code className="bg-stone-100 px-1 py-0.5 rounded">{API_BASE_URL}</code>
         </p>
+        {selectedRouteId ? (
+          <p className="text-stone-600">
+            Showing vehicles, stops and route geometry for <strong>{selectedRouteId}</strong> on the map.
+          </p>
+        ) : (
+          <p className="text-stone-600">Select a route to focus the map and highlight its live vehicles.</p>
+        )}
       </div>
     </aside>
   );

--- a/frontend/components/TransportMap.tsx
+++ b/frontend/components/TransportMap.tsx
@@ -1,16 +1,42 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import maplibregl, { Map as MapLibreMap, Marker } from 'maplibre-gl';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import maplibregl, { GeoJSONSource, Map as MapLibreMap, Marker } from 'maplibre-gl';
+import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { getSnapshot, type VehiclePosition } from '../lib/api';
+import { getSnapshot, getStops, type Route, type Stop, type VehiclePosition } from '../lib/api';
 import { API_BASE_URL, EXPLICIT_WS_URL } from '../lib/config';
 
 const TILE_STYLE = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+const DEFAULT_CENTER: [number, number] = [-2.244644, 53.483959];
+const DEFAULT_ZOOM = 11;
 
 interface MarkerState {
   marker: Marker;
   vehicleId: string;
+  routeId: string;
+}
+
+interface TransportMapProps {
+  routes: Route[];
+  selectedMode: 'all' | Route['mode'];
+  selectedRouteId: string | null;
+}
+
+interface StopProperties {
+  id: string;
+  name: string;
+  routeId: string;
+  color: string;
+  selected: boolean;
+  dimmed: boolean;
+}
+
+interface RouteLineProperties {
+  routeId: string;
+  color: string;
+  selected: boolean;
+  name: string;
 }
 
 function resolveWebSocketUrl() {
@@ -20,30 +46,198 @@ function resolveWebSocketUrl() {
   return API_BASE_URL.replace(/^http/, 'ws').replace(/\/?$/, '') + '/live';
 }
 
-function createMarker(vehicle: VehiclePosition) {
-  const el = document.createElement('div');
-  el.className = 'w-3 h-3 rounded-full border border-white shadow';
-  el.style.backgroundColor = vehicle.routeId.startsWith('tram') ? '#FFCD00' : '#005CAB';
-  el.setAttribute('title', `${vehicle.routeId} • ${Math.round(vehicle.speedKph)} km/h`);
-  return new Marker({ element: el }).setLngLat([vehicle.longitude, vehicle.latitude]);
+function defaultColorForRoute(routeId: string) {
+  return routeId.startsWith('tram') ? '#FFCD00' : '#005CAB';
 }
 
-function updateMarker(marker: Marker, vehicle: VehiclePosition) {
-  marker.setLngLat([vehicle.longitude, vehicle.latitude]);
-  marker.getElement().setAttribute('title', `${vehicle.routeId} • ${Math.round(vehicle.speedKph)} km/h`);
+function formatVehicleTitle(vehicle: VehiclePosition, route?: Route) {
+  const speed = Number.isFinite(vehicle.speedKph) ? `${Math.round(vehicle.speedKph)} km/h` : 'Speed unavailable';
+  return route ? `${route.name} • ${speed}` : `${vehicle.routeId} • ${speed}`;
 }
 
-export default function TransportMap() {
+export default function TransportMap({ routes, selectedMode, selectedRouteId }: TransportMapProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
+  const mapLoadedRef = useRef(false);
   const markersRef = useRef<Map<string, MarkerState>>(new Map());
-  const [error, setError] = useState<string | null>(null);
+  const stopsRef = useRef<Stop[]>([]);
+  const routesByIdRef = useRef<Map<string, Route>>(new Map());
+  const filtersRef = useRef({ mode: selectedMode, routeId: selectedRouteId });
+  const [vehicleError, setVehicleError] = useState<string | null>(null);
+  const [stopsError, setStopsError] = useState<string | null>(null);
+
+  const routeLookup = useMemo(() => new Map(routes.map((route) => [route.id, route])), [routes]);
+  routesByIdRef.current = routeLookup;
+  filtersRef.current = { mode: selectedMode, routeId: selectedRouteId };
+
+  const createMarker = (vehicle: VehiclePosition) => {
+    const route = routesByIdRef.current.get(vehicle.routeId);
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.className =
+      'group w-3 h-3 rounded-full border border-white shadow transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500';
+    el.style.backgroundColor = route?.color ?? defaultColorForRoute(vehicle.routeId);
+    el.dataset.routeId = vehicle.routeId;
+    el.dataset.mode = route?.mode ?? 'bus';
+    const title = formatVehicleTitle(vehicle, route);
+    el.setAttribute('title', title);
+    el.setAttribute('aria-label', title);
+    return new Marker({ element: el }).setLngLat([vehicle.longitude, vehicle.latitude]);
+  };
+
+  const updateMarker = (marker: Marker, vehicle: VehiclePosition) => {
+    const route = routesByIdRef.current.get(vehicle.routeId);
+    const title = formatVehicleTitle(vehicle, route);
+    marker.setLngLat([vehicle.longitude, vehicle.latitude]);
+    marker.getElement().setAttribute('title', title);
+    marker.getElement().setAttribute('aria-label', title);
+  };
+
+  const buildStopFeatures = (): FeatureCollection<Point, StopProperties> => {
+    const stops = stopsRef.current;
+    const features: Feature<Point, StopProperties>[] = stops
+      .filter((stop) => {
+        const route = routesByIdRef.current.get(stop.routeId);
+        if (!route) return false;
+        if (filtersRef.current.mode !== 'all' && route.mode !== filtersRef.current.mode) return false;
+        return true;
+      })
+      .map((stop) => {
+        const route = routesByIdRef.current.get(stop.routeId);
+        const isSelected = Boolean(filtersRef.current.routeId && stop.routeId === filtersRef.current.routeId);
+        const isDimmed = Boolean(filtersRef.current.routeId && stop.routeId !== filtersRef.current.routeId);
+        return {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [stop.longitude, stop.latitude],
+          },
+          properties: {
+            id: stop.id,
+            name: stop.name,
+            routeId: stop.routeId,
+            color: route?.color ?? defaultColorForRoute(stop.routeId),
+            selected: isSelected,
+            dimmed: isDimmed,
+          },
+        };
+      });
+
+    return {
+      type: 'FeatureCollection',
+      features,
+    };
+  };
+
+  const buildRouteLineFeatures = (): FeatureCollection<LineString, RouteLineProperties> => {
+    const grouped = new Map<string, Stop[]>();
+    for (const stop of stopsRef.current) {
+      const route = routesByIdRef.current.get(stop.routeId);
+      if (!route) continue;
+      if (filtersRef.current.mode !== 'all' && route.mode !== filtersRef.current.mode) continue;
+      if (!grouped.has(stop.routeId)) {
+        grouped.set(stop.routeId, []);
+      }
+      grouped.get(stop.routeId)!.push(stop);
+    }
+
+    const features: Feature<LineString, RouteLineProperties>[] = [];
+    for (const [routeId, stops] of grouped.entries()) {
+      if (stops.length < 2) continue;
+      const route = routesByIdRef.current.get(routeId);
+      const coordinates = stops.map((stop) => [stop.longitude, stop.latitude] as [number, number]);
+      features.push({
+        type: 'Feature',
+        geometry: {
+          type: 'LineString',
+          coordinates,
+        },
+        properties: {
+          routeId,
+          color: route?.color ?? defaultColorForRoute(routeId),
+          selected: Boolean(filtersRef.current.routeId && routeId === filtersRef.current.routeId),
+          name: route?.name ?? routeId,
+        },
+      });
+    }
+
+    return {
+      type: 'FeatureCollection',
+      features,
+    };
+  };
+
+  const applyMarkerFilters = useCallback(() => {
+    const { mode, routeId } = filtersRef.current;
+    markersRef.current.forEach(({ marker, routeId: markerRouteId }) => {
+      const route = routesByIdRef.current.get(markerRouteId);
+      const element = marker.getElement();
+      const matchesMode = mode === 'all' || route?.mode === mode;
+      if (!matchesMode) {
+        element.style.display = 'none';
+        return;
+      }
+      element.style.display = 'block';
+      element.style.backgroundColor = route?.color ?? defaultColorForRoute(markerRouteId);
+      if (routeId && markerRouteId !== routeId) {
+        element.style.opacity = '0.3';
+        element.style.transform = 'scale(0.85)';
+        element.style.zIndex = '10';
+      } else {
+        element.style.opacity = '1';
+        element.style.transform = routeId ? 'scale(1.3)' : 'scale(1)';
+        element.style.zIndex = routeId ? '30' : '10';
+      }
+    });
+  }, []);
+
+  const updateOverlays = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !mapLoadedRef.current) return;
+    const stopsSource = map.getSource('stops') as GeoJSONSource | undefined;
+    if (stopsSource) {
+      stopsSource.setData(buildStopFeatures());
+    }
+    const routesSource = map.getSource('route-lines') as GeoJSONSource | undefined;
+    if (routesSource) {
+      routesSource.setData(buildRouteLineFeatures());
+    }
+  }, []);
+
+  const focusSelectedRoute = useCallback(() => {
+    const map = mapRef.current;
+    if (!map || !mapLoadedRef.current) return;
+    const { routeId } = filtersRef.current;
+    if (!routeId) return;
+    const coordinates: [number, number][] = [];
+    const stops = stopsRef.current.filter((stop) => stop.routeId === routeId);
+    if (stops.length > 0) {
+      for (const stop of stops) {
+        coordinates.push([stop.longitude, stop.latitude]);
+      }
+    } else {
+      markersRef.current.forEach(({ marker, routeId: markerRouteId }) => {
+        if (markerRouteId !== routeId) return;
+        const lngLat = marker.getLngLat();
+        coordinates.push([lngLat.lng, lngLat.lat]);
+      });
+    }
+    if (coordinates.length === 0) {
+      return;
+    }
+    const bounds = coordinates.slice(1).reduce(
+      (acc, coord) => acc.extend(coord),
+      new maplibregl.LngLatBounds(coordinates[0], coordinates[0]),
+    );
+    map.fitBounds(bounds, { padding: 80, maxZoom: 14, duration: 700 });
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current || mapRef.current) {
       return;
     }
 
+    let isMounted = true;
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: {
@@ -65,8 +259,8 @@ export default function TransportMap() {
           },
         ],
       },
-      center: [-2.244644, 53.483959],
-      zoom: 11,
+      center: DEFAULT_CENTER,
+      zoom: DEFAULT_ZOOM,
     });
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }));
@@ -76,60 +270,225 @@ export default function TransportMap() {
 
     getSnapshot()
       .then((snapshot) => {
+        if (!isMounted) return;
         snapshot.features.forEach((feature) => {
           const vehicle = feature.properties;
           const marker = createMarker(vehicle);
-          currentMarkers.set(vehicle.id, { marker, vehicleId: vehicle.id });
+          currentMarkers.set(vehicle.id, { marker, vehicleId: vehicle.id, routeId: vehicle.routeId });
           marker.addTo(map);
         });
-        setError(null);
+        applyMarkerFilters();
+        setVehicleError(null);
       })
       .catch((err) => {
         console.error(err);
-        setError('Could not load vehicle positions');
+        if (isMounted) {
+          setVehicleError('Could not load vehicle positions');
+        }
       });
 
-    const socket = new WebSocket(resolveWebSocketUrl());
-
-    socket.addEventListener('message', (event) => {
-      try {
-        const payload = JSON.parse(event.data) as { type: string; vehicles?: VehiclePosition[] };
-        if (payload.type === 'vehicle-update' && payload.vehicles) {
-          payload.vehicles.forEach((vehicle) => {
-            const existing = currentMarkers.get(vehicle.id);
-            if (existing) {
-              updateMarker(existing.marker, vehicle);
-            } else {
-              const marker = createMarker(vehicle);
-              currentMarkers.set(vehicle.id, { marker, vehicleId: vehicle.id });
-              marker.addTo(map);
-            }
-          });
-        }
-      } catch (error) {
-        console.error('Failed to parse websocket payload', error);
+    let socket: WebSocket | null = null;
+    try {
+      socket = new WebSocket(resolveWebSocketUrl());
+    } catch (err) {
+      console.error(err);
+      if (isMounted) {
+        setVehicleError('Realtime connection unavailable. Showing last snapshot.');
       }
-    });
+    }
 
-    socket.addEventListener('error', () => {
-      setError('Live updates unavailable. Showing last snapshot.');
+    if (socket) {
+      socket.addEventListener('message', (event) => {
+        try {
+          const payload = JSON.parse(event.data) as { type: string; vehicles?: VehiclePosition[] };
+          if (payload.type === 'vehicle-update' && payload.vehicles) {
+            payload.vehicles.forEach((vehicle) => {
+              const existing = currentMarkers.get(vehicle.id);
+              if (existing) {
+                updateMarker(existing.marker, vehicle);
+              } else {
+                const marker = createMarker(vehicle);
+                currentMarkers.set(vehicle.id, { marker, vehicleId: vehicle.id, routeId: vehicle.routeId });
+                marker.addTo(map);
+              }
+            });
+            applyMarkerFilters();
+          }
+        } catch (error) {
+          console.error('Failed to parse websocket payload', error);
+        }
+      });
+
+      socket.addEventListener('error', () => {
+        if (isMounted) {
+          setVehicleError('Live updates unavailable. Showing last snapshot.');
+        }
+      });
+      socket.addEventListener('close', () => {
+        if (isMounted) {
+          setVehicleError((prev) => prev ?? 'Live updates unavailable. Showing last snapshot.');
+        }
+      });
+    }
+
+    map.on('load', () => {
+      mapLoadedRef.current = true;
+      map.addSource('route-lines', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      });
+      map.addLayer({
+        id: 'route-lines',
+        type: 'line',
+        source: 'route-lines',
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round',
+        },
+        paint: {
+          'line-color': ['get', 'color'],
+          'line-width': [
+            'case',
+            ['boolean', ['get', 'selected'], false],
+            5,
+            3,
+          ],
+          'line-opacity': [
+            'case',
+            ['boolean', ['get', 'selected'], false],
+            0.95,
+            0.35,
+          ],
+        },
+      });
+
+      map.addSource('stops', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      });
+      map.addLayer({
+        id: 'stops-circles',
+        type: 'circle',
+        source: 'stops',
+        paint: {
+          'circle-color': ['get', 'color'],
+          'circle-radius': [
+            'case',
+            ['boolean', ['get', 'selected'], false],
+            6,
+            ['boolean', ['get', 'dimmed'], false],
+            3,
+            4.5,
+          ],
+          'circle-opacity': [
+            'case',
+            ['boolean', ['get', 'selected'], false],
+            0.95,
+            ['boolean', ['get', 'dimmed'], false],
+            0.3,
+            0.7,
+          ],
+          'circle-stroke-color': '#ffffff',
+          'circle-stroke-width': 1,
+        },
+      });
+      map.addLayer({
+        id: 'stops-labels',
+        type: 'symbol',
+        source: 'stops',
+        minzoom: 13,
+        layout: {
+          'text-field': ['get', 'name'],
+          'text-size': 11,
+          'text-offset': [0, 1],
+          'text-allow-overlap': false,
+        },
+        paint: {
+          'text-color': '#1f2937',
+          'text-halo-color': '#ffffff',
+          'text-halo-width': 1,
+          'text-opacity': [
+            'case',
+            ['boolean', ['get', 'dimmed'], false],
+            0.2,
+            0.9,
+          ],
+        },
+      });
+      updateOverlays();
     });
 
     return () => {
-      socket.close();
+      isMounted = false;
+      mapLoadedRef.current = false;
+      if (socket) {
+        socket.close();
+      }
       map.remove();
       mapRef.current = null;
       currentMarkers.forEach(({ marker }) => marker.remove());
       currentMarkers.clear();
     };
-  }, []);
+  }, [applyMarkerFilters, updateOverlays]);
+
+  useEffect(() => {
+    applyMarkerFilters();
+    updateOverlays();
+  }, [applyMarkerFilters, updateOverlays, routes, selectedMode, selectedRouteId]);
+
+  useEffect(() => {
+    if (!selectedRouteId) {
+      if (mapRef.current && mapLoadedRef.current) {
+        mapRef.current.easeTo({ center: DEFAULT_CENTER, zoom: DEFAULT_ZOOM, duration: 600 });
+      }
+      return;
+    }
+    focusSelectedRoute();
+  }, [focusSelectedRoute, selectedRouteId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStops() {
+      try {
+        const data = await getStops();
+        if (cancelled) return;
+        stopsRef.current = data;
+        setStopsError(null);
+        updateOverlays();
+        if (filtersRef.current.routeId) {
+          focusSelectedRoute();
+        }
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setStopsError('Could not load stops');
+        }
+      }
+    }
+
+    loadStops();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [focusSelectedRoute, updateOverlays]);
+
+  const messages = [vehicleError, stopsError].filter((message): message is string => Boolean(message));
 
   return (
     <div className="relative h-full">
       <div ref={containerRef} className="absolute inset-0" />
-      {error ? (
-        <div className="absolute bottom-4 left-4 right-4 md:right-auto bg-white/80 backdrop-blur rounded shadow p-3 text-sm text-red-600">
-          {error}
+      {messages.length > 0 ? (
+        <div className="absolute bottom-4 left-4 right-4 md:right-auto flex flex-col gap-2 text-sm">
+          {messages.map((message, index) => (
+            <div
+              key={index}
+              className="bg-white/90 backdrop-blur rounded border border-red-100 shadow text-red-700 px-3 py-2"
+            >
+              {message}
+            </div>
+          ))}
         </div>
       ) : null}
     </div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "18.2.0"
       },
       "devDependencies": {
+        "@types/geojson": "^7946.0.10",
         "@types/node": "^20.11.30",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@types/geojson": "^7946.0.10",
     "@types/node": "^20.11.30",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",


### PR DESCRIPTION
## Summary
- load routes on the client, share mode/route selection between the sidebar and map, and pass configuration to the dynamic map component
- update the route sidebar UI with loading/error states, selection toggles, and contextual messaging for the focused route
- enhance the TransportMap with stop and route overlays, live filtering, focus animations, and clearer realtime error handling

## Testing
- npm run lint (frontend)
- npm test (backend)


------
https://chatgpt.com/codex/tasks/task_e_68cd52c5ef40832abb5a0163e688e02a