### PR TITLE
Fix missing map tiles

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import '../styles/globals.css';
 
 export const metadata: Metadata = {

--- a/frontend/components/TransportMap.tsx
+++ b/frontend/components/TransportMap.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import maplibregl, { GeoJSONSource, Map as MapLibreMap, Marker } from 'maplibre-gl';
 import type { Feature, FeatureCollection, LineString, Point } from 'geojson';
-import 'maplibre-gl/dist/maplibre-gl.css';
 import { getSnapshot, getStops, type Route, type Stop, type VehiclePosition } from '../lib/api';
 import { API_BASE_URL, EXPLICIT_WS_URL } from '../lib/config';
 


### PR DESCRIPTION
## Summary
- load MapLibre's stylesheet from the root layout so the base map renders correctly
- drop the redundant component-level CSS import now that the styles are global

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd58502a4c832aa49c32332fa26c47